### PR TITLE
Fix README default max_tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ python main.py --max_tokens 200 --context_length 15
 ```
 
 ### オプション
-- `--max_tokens`: 出力の最大トークン数（デフォルト: 150）
+- `--max_tokens`: 出力の最大トークン数（デフォルト: 500）
 - `--context_length`: 保持する会話の最大数（デフォルト: 10）
 
 ## 終了方法

--- a/main.py
+++ b/main.py
@@ -392,7 +392,7 @@ JSONだけを返し、マークダウンのコードブロックで囲まない�
 
 def main():
     parser = argparse.ArgumentParser(description="CLI AI エージェント")
-    parser.add_argument('--max_tokens', type=int, default=DEFAULT_MAX_TOKENS, help="出力の最大トークン数")
+    parser.add_argument('--max_tokens', type=int, default=DEFAULT_MAX_TOKENS, help="出力の最大トークン数 (デフォルト: %(default)s)")
     parser.add_argument('--context_length', type=int, default=DEFAULT_CONTEXT_LENGTH, help="保存する会話の最大数")
     parser.add_argument('--model', type=str, default=DEFAULT_MODEL, help="使用するGeminiモデル")
     parser.add_argument('--task', type=str, help="タスクを指定（例: コード生成）")


### PR DESCRIPTION
## Summary
- update README to show default max tokens of 500
- document the default in command line help

## Testing
- `python -m py_compile main.py tools.py ai_workflow_controller.py workflow.py workflow_utils.py workflow_types.py`
- `python - <<'EOF'
import runpy, sys, types
sys.modules['google'] = types.ModuleType('google')
sys.modules['google.generativeai'] = types.ModuleType('google.generativeai')
sys.argv = ['main.py', '--help']
try:
    runpy.run_path('main.py', run_name='__main__')
except SystemExit:
    pass
EOF`